### PR TITLE
Use wall clock timestamp for credential creation

### DIFF
--- a/aws_hello_creds.py
+++ b/aws_hello_creds.py
@@ -96,7 +96,8 @@ class AWSCredentialManager:
             credential_data = {
                 "aws_access_key_id": access_key,
                 "aws_secret_access_key": secret_key,
-                "created_at": asyncio.get_event_loop().time(),
+                # Use wall clock time for creation timestamp
+                "created_at": time.time(),
                 "profile_name": profile_name
             }
             


### PR DESCRIPTION
## Summary
- store credential `created_at` using `time.time()` instead of event loop clock
- ensure other credential metadata uses wall clock time

## Testing
- `pytest` *(fails: module 'ctypes' has no attribute 'windll')*
- `python -m py_compile aws_hello_creds.py`


------
https://chatgpt.com/codex/tasks/task_e_689384cfcd948320a519ef28ced2f74a