### PR TITLE
Harden file path validation and add tests

### DIFF
--- a/security_utils.py
+++ b/security_utils.py
@@ -139,8 +139,19 @@ def validate_file_path(file_path: str, operation: str = "access") -> Path:
     Raises:
         ValidationError: If path is invalid or unsafe
     """
+    raw_path = Path(file_path)
+
+    # Inspect raw path for traversal attempts before resolving
+    if any(part == ".." for part in raw_path.parts):
+        audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
+            'error': 'path_traversal_attempt',
+            'path': file_path,
+            'operation': operation
+        })
+        raise ValidationError("Path traversal not allowed")
+
     try:
-        path = Path(file_path).resolve()
+        path = raw_path.resolve()
     except (OSError, ValueError) as e:
         audit_log(SECURITY_EVENTS['VALIDATION_ERROR'], {
             'error': 'invalid_path',
@@ -148,9 +159,23 @@ def validate_file_path(file_path: str, operation: str = "access") -> Path:
             'operation': operation
         })
         raise ValidationError(f"Invalid file path: {e}")
-    
-    # Check for path traversal attempts
-    if '..' in str(path) or str(path).startswith('/'):
+
+    base_dir = Path.cwd().resolve()
+
+    # Disallow absolute paths outside the allowed base directory
+    if raw_path.is_absolute():
+        try:
+            path.relative_to(base_dir)
+        except ValueError:
+            audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
+                'error': 'path_traversal_attempt',
+                'path': str(path),
+                'operation': operation
+            })
+            raise ValidationError("Absolute paths outside the allowed directory are not permitted")
+
+    # Ensure resolved path remains within the allowed directory
+    if not path.is_relative_to(base_dir):
         audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
             'error': 'path_traversal_attempt',
             'path': str(path),

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -60,9 +60,11 @@ class TestFileValidation:
     """Test file path validation."""
     
     def test_validate_file_path_valid(self):
-        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+        base_dir = Path.cwd()
+        with tempfile.NamedTemporaryFile(dir=base_dir, suffix='.txt', delete=False) as f:
+            rel_path = os.path.relpath(f.name, start=base_dir)
             try:
-                path = validate_file_path(f.name, "read")
+                path = validate_file_path(rel_path, "read")
                 assert isinstance(path, Path)
             finally:
                 try:
@@ -75,21 +77,25 @@ class TestFileValidation:
             validate_file_path("malicious.exe", "read")
     
     def test_validate_file_path_traversal_attempt(self):
-        # This test might not raise on Windows - that's expected
-        try:
-            validate_file_path("../../../etc/passwd", "read")
-        except ValidationError:
-            pass  # Expected on some systems
+        with pytest.raises(ValidationError):
+            validate_file_path("../etc/passwd", "read")
+
+    def test_validate_file_path_absolute_path_non_windows(self):
+        if os.name != "nt":
+            with pytest.raises(ValidationError):
+                validate_file_path("/etc/passwd", "read")
     
     def test_validate_file_path_large_file(self):
-        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+        base_dir = Path.cwd()
+        with tempfile.NamedTemporaryFile(dir=base_dir, suffix='.txt', delete=False) as f:
             try:
                 # Write a large file
                 f.write(b'x' * (101 * 1024 * 1024))  # 101MB
                 f.flush()
-                
+
+                rel_path = os.path.relpath(f.name, start=base_dir)
                 with pytest.raises(ValidationError, match="File too large"):
-                    validate_file_path(f.name, "read")
+                    validate_file_path(rel_path, "read")
             finally:
                 try:
                     os.unlink(f.name)


### PR DESCRIPTION
## Summary
- detect `..` segments before resolving paths
- block absolute paths outside working directory with platform-aware check
- add tests for absolute path and `../` traversal handling

## Testing
- `pytest tests/test_security_utils.py -q`
- `pytest -q` *(fails: module 'ctypes' has no attribute 'windll')*

------
https://chatgpt.com/codex/tasks/task_e_689384d95ba883208310dd67b055a6f1