### PR TITLE
Use ctypes buffer address for secure memory clear

### DIFF
--- a/security_utils.py
+++ b/security_utils.py
@@ -246,7 +246,9 @@ def secure_memory_clear(data: bytearray) -> None:
             # Use Windows SecureZeroMemory if available
             kernel32 = ctypes.windll.kernel32
             kernel32.RtlSecureZeroMemory.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
-            kernel32.RtlSecureZeroMemory(ctypes.addressof(data), len(data))
+            address = ctypes.addressof(ctypes.c_char.from_buffer(data))
+            # Convert bytearray to ctypes buffer to obtain memory address
+            kernel32.RtlSecureZeroMemory(address, len(data))
     except Exception:
         # Fallback to multiple overwrites
         for _ in range(3):

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -145,6 +145,18 @@ class TestSecurityFunctions:
         secure_memory_clear(data)
         # Data should be zeroed
         assert all(b == 0 for b in data)
+
+    def test_secure_memory_clear_windows(self):
+        data = bytearray(b"sensitive_data")
+        mock_rtl = MagicMock()
+        mock_kernel32 = MagicMock()
+        mock_kernel32.RtlSecureZeroMemory = mock_rtl
+        with patch('platform.system', return_value='Windows'), \
+             patch('ctypes.windll', create=True) as mock_dll:
+            mock_dll.kernel32 = mock_kernel32
+            secure_memory_clear(data)
+            mock_rtl.assert_called_once()
+        assert all(b == 0 for b in data)
     
     def test_constant_time_compare(self):
         data1 = b"test_data"


### PR DESCRIPTION
## Summary
- ensure RtlSecureZeroMemory receives the buffer's address by converting the bytearray to a ctypes buffer first
- document bytearray-to-buffer conversion
- add test that mocks Windows APIs and verifies secure memory clearing path

## Testing
- `pytest tests/test_security_utils.py::TestSecurityFunctions::test_secure_memory_clear -q`
- `pytest tests/test_security_utils.py::TestSecurityFunctions::test_secure_memory_clear_windows -q`
- `pytest -q` *(fails: AttributeError: module 'ctypes' has no attribute 'windll')*

------
https://chatgpt.com/codex/tasks/task_e_689384da4210832094dd4ffebf7ac67b