### PR TITLE
Use async file IO in encryption

### DIFF
--- a/hello_crypto.py
+++ b/hello_crypto.py
@@ -469,38 +469,36 @@ class FileEncryptor:
         await self.ensure_key_exists()
         key = await self.derive_key_from_signature()
         key_array = bytearray(key)
-        
+
+        temp_output = output_file.with_suffix('.tmp')
+
         try:
             # Read input file with size validation
             if not input_file.exists():
                 raise FileNotFoundError(f"Input file not found: {input_file}")
-                
-            with open(input_file, "rb") as f:
-                plaintext = f.read()
-            
+
+            plaintext = await asyncio.to_thread(input_file.read_bytes)
+
             if len(plaintext) == 0:
                 raise ValueError("Cannot encrypt empty file")
-            
+
             # Encrypt data
             ciphertext = self.encrypt_data(plaintext, key)
-            
+
             # Write output file atomically
-            temp_output = output_file.with_suffix('.tmp')
-            with open(temp_output, "wb") as f:
-                f.write(ciphertext)
-            
+            await asyncio.to_thread(temp_output.write_bytes, ciphertext)
+
             # Atomic rename
             temp_output.replace(output_file)
-            
+
             logger.info(f"File encryption completed: {output_file.name}")
-                
+
         except Exception as e:
             audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
                 'operation': 'file_encryption',
                 'error': str(e)[:100]
             })
             # Clean up temporary file if it exists
-            temp_output = Path(str(output_path) + '.tmp')
             if temp_output.exists():
                 temp_output.unlink()
             raise
@@ -525,38 +523,36 @@ class FileEncryptor:
         await self.ensure_key_exists()
         key = await self.derive_key_from_signature()
         key_array = bytearray(key)
-        
+
+        temp_output = output_file.with_suffix('.tmp')
+
         try:
             # Read input file with validation
             if not input_file.exists():
                 raise FileNotFoundError(f"Input file not found: {input_file}")
-                
-            with open(input_file, "rb") as f:
-                ciphertext = f.read()
-            
+
+            ciphertext = await asyncio.to_thread(input_file.read_bytes)
+
             if len(ciphertext) == 0:
                 raise ValueError("Cannot decrypt empty file")
-            
+
             # Decrypt data
             plaintext = self.decrypt_data(ciphertext, key)
-            
+
             # Write output file atomically
-            temp_output = output_file.with_suffix('.tmp')
-            with open(temp_output, "wb") as f:
-                f.write(plaintext)
-            
+            await asyncio.to_thread(temp_output.write_bytes, plaintext)
+
             # Atomic rename
             temp_output.replace(output_file)
-            
+
             logger.info(f"File decryption completed: {output_file.name}")
-                
+
         except Exception as e:
             audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
                 'operation': 'file_decryption',
                 'error': str(e)[:100]
             })
             # Clean up temporary file if it exists
-            temp_output = Path(str(output_path) + '.tmp')
             if temp_output.exists():
                 temp_output.unlink()
             raise

--- a/tests/test_hello_crypto.py
+++ b/tests/test_hello_crypto.py
@@ -2,6 +2,7 @@
 Unit tests for hello_crypto module
 """
 
+import asyncio
 import pytest
 import tempfile
 import os
@@ -131,21 +132,32 @@ class TestFileEncryptor:
             
             # Write test data
             input_file.write_bytes(test_data)
-            
-            # Mock Windows Hello operations
-            with patch.object(encryptor, 'is_supported', return_value=True), \
+
+            real_to_thread = asyncio.to_thread
+
+            async def side_effect(func, *args, **kwargs):
+                return await real_to_thread(func, *args, **kwargs)
+
+            # Mock Windows Hello operations and track async file operations
+            with patch('hello_crypto.asyncio.to_thread', new_callable=AsyncMock) as mock_to_thread, \
+                 patch.object(encryptor, 'is_supported', return_value=True), \
                  patch.object(encryptor, 'ensure_key_exists', return_value=None), \
                  patch.object(encryptor, 'derive_key_from_signature', return_value=secrets.token_bytes(AES_KEY_SIZE)):
-                
+
+                mock_to_thread.side_effect = side_effect
+
                 # Encrypt file
                 await encryptor.encrypt_file(str(input_file), str(encrypted_file))
                 assert encrypted_file.exists()
                 assert encrypted_file.read_bytes() != test_data
-                
+
                 # Decrypt file
                 await encryptor.decrypt_file(str(encrypted_file), str(decrypted_file))
                 assert decrypted_file.exists()
                 assert decrypted_file.read_bytes() == test_data
+
+                # Ensure async file operations were performed via to_thread
+                assert mock_to_thread.await_count >= 4
         finally:
             # Clean up test files
             import shutil


### PR DESCRIPTION
## Summary
- Offload file reads and writes in FileEncryptor to `asyncio.to_thread` for non-blocking IO with secure temp-file handling
- Track and assert async file operations in encryption/decryption tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893ab047f5c832082ccf6d981f4c394