### PR TITLE
feat: use pyproject as version source

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,15 +13,6 @@ on:
         options:
         - testpypi
         - pypi
-      version_increment:
-        description: 'Version increment type (if not using git tag)'
-        required: false
-        default: 'patch'
-        type: choice
-        options:
-        - patch
-        - minor
-        - major
 
 jobs:
   test:
@@ -81,65 +72,10 @@ jobs:
     - name: Determine version
       id: version
       run: |
-        # Check if we have a git tag that looks like a version
-        if git describe --tags --exact-match 2>/dev/null | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+'; then
-          # Use git tag as version (remove 'v' prefix if present)
-          VERSION=$(git describe --tags --exact-match | sed 's/^v//')
-          echo "Using git tag version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-        else
-          # Auto-increment version based on input or default to patch
-          INCREMENT_TYPE="${{ github.event.inputs.version_increment || 'patch' }}"
-          CURRENT_VERSION=$(python -c "import tomllib; import sys; f=open('pyproject.toml','rb'); config=tomllib.load(f); f.close(); print(config['project']['version'])")
-          
-          # Parse version components
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-          
-          case $INCREMENT_TYPE in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
-          
-          VERSION="$MAJOR.$MINOR.$PATCH"
-          echo "Auto-incremented version ($INCREMENT_TYPE): $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-        fi
-    
-    - name: Update pyproject.toml version
-      run: |
-        # Install tomli_w for writing TOML
-        pip install tomli_w
-        
-        # Update version in pyproject.toml
-        python -c "
-        import tomllib
-        import tomli_w
-        import os
-        
-        version = os.environ['VERSION']
-        
-        with open('pyproject.toml', 'rb') as f:
-            config = tomllib.load(f)
-        
-        config['project']['version'] = version
-        
-        with open('pyproject.toml', 'wb') as f:
-            tomli_w.dump(config, f)
-        
-        print(f'Updated pyproject.toml to version {version}')
-        "
+        VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+        echo "Using project version: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
     
     - name: Verify package metadata
       run: |
@@ -297,4 +233,3 @@ jobs:
         echo "### Publishing Method" >> $env:GITHUB_STEP_SUMMARY
         echo "- ✅ **Trusted Publishers**: Secure authentication without API tokens" >> $env:GITHUB_STEP_SUMMARY
         echo "- ✅ **Skip Existing**: Robust handling of duplicate uploads" >> $env:GITHUB_STEP_SUMMARY
-        echo "- ✅ **Auto-versioning**: Automatic version management" >> $env:GITHUB_STEP_SUMMARY

--- a/docs/PYPI_DEPLOYMENT.md
+++ b/docs/PYPI_DEPLOYMENT.md
@@ -7,9 +7,10 @@ WinHello-Crypto is now officially available on the Python Package Index (PyPI), 
 ## 🎉 Current Status: LIVE on PyPI
 
 - **Package URL**: [https://pypi.org/project/winhello-crypto/](https://pypi.org/project/winhello-crypto/)
-- **Version**: 2.0.0
+- **Version**: 2.1.3
 - **Published**: August 6, 2025
 - **Console Scripts**: `aws-hello-creds` and `winhello-crypto`
+- **Version Management**: Version number comes directly from `pyproject.toml`
 
 ## Installation for Users
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "winhello-crypto"
-version = "2.1.2"
+version = "2.1.3"
 description = "Enterprise-Grade AWS Credential Security with Windows Hello Biometric Authentication"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,16 @@ Setup script for WinHello-Crypto
 
 from setuptools import setup, find_packages
 from pathlib import Path
+import re
+
+# Load version from pyproject.toml so that it remains the single source of truth
+pyproject_file = Path(__file__).parent / "pyproject.toml"
+version_match = re.search(
+    r'^version\s*=\s*"([^"\n]+)"',
+    pyproject_file.read_text(encoding="utf-8"),
+    re.MULTILINE,
+)
+project_version = version_match.group(1) if version_match else "0.0.0"
 
 # Read README for long description
 readme_file = Path(__file__).parent / "README.md"
@@ -25,7 +35,7 @@ else:
 
 setup(
     name="winhello-crypto",
-    version="2.0.0",
+    version=project_version,
     author="Serge Dubovsky",
     author_email="",
     description="Enterprise-Grade AWS Credential Security with Windows Hello Biometric Authentication",


### PR DESCRIPTION
## Summary
- use pyproject.toml as canonical version
- load version from pyproject in setup.py and CI workflow
- document new version management

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893aec17e348320b72f596a197aa9b9