### PR TITLE
Switch to AEAD encryption

### DIFF
--- a/ci_test_runner.py
+++ b/ci_test_runner.py
@@ -16,7 +16,7 @@ def test_imports():
         sys.path.insert(0, '.')
         
         # Test security modules (should work on all platforms)
-        from security_config import AES_KEY_SIZE, AES_BLOCK_SIZE
+        from security_config import AES_KEY_SIZE, AES_GCM_NONCE_SIZE
         print(f"[PASS] security_config imported (AES_KEY_SIZE={AES_KEY_SIZE})")
         
         from security_utils import ValidationError, SecurityError

--- a/hello_crypto.py
+++ b/hello_crypto.py
@@ -9,9 +9,10 @@ import time
 from pathlib import Path
 from typing import Optional, Dict, Any
 
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-from cryptography.hazmat.primitives import padding, hashes, hmac
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.backends import default_backend
 
 try:
@@ -48,11 +49,11 @@ except ImportError:
 # Import security utilities
 from security_utils import (
     SecurityError, ValidationError, RateLimitError, rate_limiter,
-    audit_log, validate_file_path, secure_memory_clear, 
-    sanitize_error_message, constant_time_compare
+    audit_log, validate_file_path, secure_memory_clear,
+    sanitize_error_message
 )
 from security_config import (
-    AES_BLOCK_SIZE, AES_KEY_SIZE, PBKDF2_ITERATIONS, 
+    AES_GCM_NONCE_SIZE, AES_GCM_TAG_SIZE, AES_KEY_SIZE, PBKDF2_ITERATIONS,
     KEY_NAME_FILE, CHALLENGE_MESSAGE, SECURITY_EVENTS
 )
 
@@ -368,85 +369,48 @@ class FileEncryptor:
             raise WindowsHelloError(f"Failed to derive key: {sanitize_error_message(e, 'key derivation')}")
     
     def encrypt_data(self, data: bytes, key: bytes) -> bytes:
-        """Encrypt data using AES-256-CBC with proper PKCS7 padding and integrity protection."""
+        """Encrypt data using AES-256-GCM providing confidentiality and integrity."""
         if len(key) != AES_KEY_SIZE:
             raise ValueError(f"Key must be {AES_KEY_SIZE} bytes")
-        
+
         if len(data) == 0:
             raise ValueError("Cannot encrypt empty data")
-        
-        # Generate cryptographically secure random IV
-        iv = secrets.token_bytes(AES_BLOCK_SIZE)
 
-        # Pad data using PKCS7
-        padder = padding.PKCS7(AES_BLOCK_SIZE * 8).padder()
-        padded_data = padder.update(data) + padder.finalize()
+        # Generate cryptographically secure random nonce
+        nonce = secrets.token_bytes(AES_GCM_NONCE_SIZE)
 
-        # Encrypt using AES-256-CBC
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        encryptor = cipher.encryptor()
-        ciphertext = encryptor.update(padded_data) + encryptor.finalize()
+        aead = AESGCM(key)
+        ciphertext = aead.encrypt(nonce, data, None)  # ciphertext includes authentication tag
 
-        # Calculate HMAC for integrity protection over IV + ciphertext
-        hmac_key = hashlib.sha256(key + b"hmac_key_derivation").digest()
-        h = hmac.HMAC(hmac_key, hashes.SHA256(), backend=default_backend())
-        h.update(iv + ciphertext)
-        data_hmac = h.finalize()
-
-        # Return IV + ciphertext + HMAC
-        result = iv + ciphertext + data_hmac
-        return result
+        # Return nonce + ciphertext (which already includes tag)
+        return nonce + ciphertext
     
     def decrypt_data(self, data: bytes, key: bytes) -> bytes:
-        """Decrypt data using AES-256-CBC with integrity verification."""
+        """Decrypt data using AES-256-GCM with integrity verification."""
         if len(key) != AES_KEY_SIZE:
             raise ValueError(f"Key must be {AES_KEY_SIZE} bytes")
-        
-        if len(data) < AES_BLOCK_SIZE + 32:  # IV + minimum HMAC + data
+
+        if len(data) < AES_GCM_NONCE_SIZE + AES_GCM_TAG_SIZE:
             raise ValueError("Invalid encrypted data: too short")
 
-        # Extract IV, ciphertext, and HMAC
-        iv = data[:AES_BLOCK_SIZE]
-        stored_hmac = data[-32:]
-        ciphertext = data[AES_BLOCK_SIZE:-32]
+        # Extract nonce and ciphertext (which includes the tag)
+        nonce = data[:AES_GCM_NONCE_SIZE]
+        ciphertext = data[AES_GCM_NONCE_SIZE:]
 
-        if len(ciphertext) == 0:
-            raise ValueError("Invalid encrypted data: missing ciphertext")
-
-        # Verify HMAC integrity before decryption
-        hmac_key = hashlib.sha256(key + b"hmac_key_derivation").digest()
-        h = hmac.HMAC(hmac_key, hashes.SHA256(), backend=default_backend())
-        h.update(iv + ciphertext)
-        expected_hmac = h.finalize()
-
-        # Constant-time comparison to prevent timing attacks
-        if not constant_time_compare(stored_hmac, expected_hmac):
+        aead = AESGCM(key)
+        try:
+            plaintext = aead.decrypt(nonce, ciphertext, None)
+        except InvalidTag:
             audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
                 'error': 'integrity_check_failed'
             })
             raise ValueError("Data integrity check failed - file may be corrupted or tampered with")
-
-        # Decrypt using AES-256-CBC
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        decryptor = cipher.decryptor()
-        try:
-            padded_plaintext = decryptor.update(ciphertext) + decryptor.finalize()
         except Exception as e:
             audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
                 'error': 'decryption_failed',
                 'details': 'cipher_decryption_error'
             })
             raise ValueError(f"Decryption failed: {sanitize_error_message(e, 'decryption')}")
-
-        # Remove PKCS7 padding
-        unpadder = padding.PKCS7(AES_BLOCK_SIZE * 8).unpadder()
-        try:
-            plaintext = unpadder.update(padded_plaintext) + unpadder.finalize()
-        except Exception as e:
-            audit_log(SECURITY_EVENTS['SECURITY_ERROR'], {
-                'error': 'padding_removal_failed'
-            })
-            raise ValueError("Invalid padding - data may be corrupted")
 
         logger.debug(f"Decryption completed, output size: {len(plaintext)} bytes")
         return plaintext

--- a/security_config.py
+++ b/security_config.py
@@ -17,10 +17,10 @@ RATE_LIMIT_WINDOW = 300  # 5 minutes in seconds
 LOCKOUT_DURATION = 900   # 15 minutes in seconds
 
 # Cryptographic constants
-AES_BLOCK_SIZE = 16
+AES_GCM_NONCE_SIZE = 12  # 96-bit nonce for AES-GCM
+AES_GCM_TAG_SIZE = 16    # 128-bit authentication tag
 AES_KEY_SIZE = 32  # 256 bits
 PBKDF2_ITERATIONS = 100000  # OWASP recommended minimum
-HMAC_SIZE = 32  # SHA-256 output size
 
 # Windows Hello constants
 KEY_NAME_FILE = "FileEncryptKey"
@@ -90,9 +90,9 @@ def get_security_config() -> Dict[str, Any]:
         },
         'crypto': {
             'aes_key_size': AES_KEY_SIZE,
-            'aes_block_size': AES_BLOCK_SIZE,
-            'pbkdf2_iterations': PBKDF2_ITERATIONS,
-            'hmac_size': HMAC_SIZE
+            'aes_gcm_nonce_size': AES_GCM_NONCE_SIZE,
+            'aes_gcm_tag_size': AES_GCM_TAG_SIZE,
+            'pbkdf2_iterations': PBKDF2_ITERATIONS
         },
         'aws_validation': {
             'patterns': AWS_PATTERNS,

--- a/tests/test_hello_crypto.py
+++ b/tests/test_hello_crypto.py
@@ -16,7 +16,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
     from hello_crypto import FileEncryptor, WindowsHelloError
-    from security_config import AES_KEY_SIZE, AES_BLOCK_SIZE
+    from security_config import AES_KEY_SIZE, AES_GCM_NONCE_SIZE, AES_GCM_TAG_SIZE
 except ImportError as e:
     pytest.skip(f"Could not import hello_crypto modules: {e}", allow_module_level=True)
 
@@ -37,7 +37,8 @@ class TestFileEncryptor:
         
         # Encrypt
         encrypted = encryptor.encrypt_data(original_data, test_key)
-        assert len(encrypted) > len(original_data)  # Should be larger due to IV and padding
+        expected_len = len(original_data) + AES_GCM_NONCE_SIZE + AES_GCM_TAG_SIZE
+        assert len(encrypted) == expected_len  # Nonce and tag added
         assert encrypted != original_data  # Should be different
         
         # Decrypt
@@ -78,21 +79,21 @@ class TestFileEncryptor:
         original_data = b"Test data for integrity check"
         encrypted = encryptor.encrypt_data(original_data, test_key)
 
-        # Corrupt the ciphertext but leave the HMAC untouched
+        # Corrupt the ciphertext but leave the tag untouched
         corrupted = bytearray(encrypted)
-        corrupted[AES_BLOCK_SIZE] ^= 1  # Flip a bit in the ciphertext portion
+        corrupted[AES_GCM_NONCE_SIZE] ^= 1  # Flip a bit in the ciphertext portion
 
         with pytest.raises(ValueError, match="Data integrity check failed"):
             encryptor.decrypt_data(bytes(corrupted), test_key)
     
     def test_encrypt_different_data_produces_different_results(self, encryptor, test_key):
-        """Test that encrypting the same data twice produces different results (due to random IV)."""
+        """Test that encrypting the same data twice produces different results (due to random nonce)."""
         data = b"Test data for randomness check"
         
         encrypted1 = encryptor.encrypt_data(data, test_key)
         encrypted2 = encryptor.encrypt_data(data, test_key)
         
-        # Should be different due to random IV
+        # Should be different due to random nonce
         assert encrypted1 != encrypted2
         
         # But both should decrypt to the same original data


### PR DESCRIPTION
## Summary
- replace AES-CBC + HMAC with AES-256-GCM
- remove HMAC handling and depend on GCM tag
- update tests and security constants for nonce/tag sizes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b40b9b848320a7a4dbd6002949cc