### PR TITLE
Switch PBKDF2 key derivation to Argon2id

### DIFF
--- a/ci_test_runner.py
+++ b/ci_test_runner.py
@@ -73,10 +73,17 @@ def test_configuration():
     print("\n[TESTING] Configuration...")
     
     try:
-        from security_config import AES_KEY_SIZE, PBKDF2_ITERATIONS, AWS_REGIONS
-        
+        from security_config import (
+            AES_KEY_SIZE, ARGON2_TIME_COST, ARGON2_MEMORY_COST, AWS_REGIONS
+        )
+
         assert AES_KEY_SIZE == 32, f"Expected AES_KEY_SIZE=32, got {AES_KEY_SIZE}"
-        assert PBKDF2_ITERATIONS > 10000, f"PBKDF2 iterations too low: {PBKDF2_ITERATIONS}"
+        assert ARGON2_TIME_COST >= 2, (
+            f"Argon2 time cost too low: {ARGON2_TIME_COST}"
+        )
+        assert ARGON2_MEMORY_COST >= 64 * 1024, (
+            f"Argon2 memory cost too low: {ARGON2_MEMORY_COST}"
+        )
         assert len(AWS_REGIONS) > 10, f"Too few AWS regions: {len(AWS_REGIONS)}"
         
         print("[PASS] Configuration constants valid")

--- a/hello_crypto.py
+++ b/hello_crypto.py
@@ -11,7 +11,7 @@ from typing import Optional, Dict, Any
 
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import padding, hashes, hmac
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
 from cryptography.hazmat.backends import default_backend
 
 try:
@@ -52,7 +52,8 @@ from security_utils import (
     sanitize_error_message, constant_time_compare
 )
 from security_config import (
-    AES_BLOCK_SIZE, AES_KEY_SIZE, PBKDF2_ITERATIONS, 
+    AES_BLOCK_SIZE, AES_KEY_SIZE,
+    ARGON2_TIME_COST, ARGON2_MEMORY_COST, ARGON2_PARALLELISM,
     KEY_NAME_FILE, CHALLENGE_MESSAGE, SECURITY_EVENTS
 )
 
@@ -330,19 +331,19 @@ class FileEncryptor:
                 })
                 raise WindowsHelloError("Biometric authentication failed or was cancelled")
 
-            # Extract signature and derive key with PBKDF2
+            # Extract signature and derive key with Argon2id
             signature = await self._extract_signature_bytes(sign_result.result)
-            
+
             # Enhanced salt generation with multiple sources (deterministic for key derivation)
             salt_material = f"{self.key_name}:{self.challenge}:{os.getenv('COMPUTERNAME', '')}"
             salt = hashlib.sha256(salt_material.encode()).digest()[:16]
-            
-            kdf = PBKDF2HMAC(
-                algorithm=hashes.SHA256(),
-                length=AES_KEY_SIZE,
+
+            kdf = Argon2id(
                 salt=salt,
-                iterations=PBKDF2_ITERATIONS,
-                backend=default_backend()
+                length=AES_KEY_SIZE,
+                iterations=ARGON2_TIME_COST,
+                lanes=ARGON2_PARALLELISM,
+                memory_cost=ARGON2_MEMORY_COST,
             )
             derived_key = kdf.derive(signature)
             

--- a/security_config.py
+++ b/security_config.py
@@ -19,7 +19,10 @@ LOCKOUT_DURATION = 900   # 15 minutes in seconds
 # Cryptographic constants
 AES_BLOCK_SIZE = 16
 AES_KEY_SIZE = 32  # 256 bits
-PBKDF2_ITERATIONS = 100000  # OWASP recommended minimum
+# Argon2id KDF parameters (OWASP recommended)
+ARGON2_TIME_COST = 2
+ARGON2_MEMORY_COST = 64 * 1024  # 64MB
+ARGON2_PARALLELISM = 1
 HMAC_SIZE = 32  # SHA-256 output size
 
 # Windows Hello constants
@@ -91,7 +94,9 @@ def get_security_config() -> Dict[str, Any]:
         'crypto': {
             'aes_key_size': AES_KEY_SIZE,
             'aes_block_size': AES_BLOCK_SIZE,
-            'pbkdf2_iterations': PBKDF2_ITERATIONS,
+            'argon2_time_cost': ARGON2_TIME_COST,
+            'argon2_memory_cost': ARGON2_MEMORY_COST,
+            'argon2_parallelism': ARGON2_PARALLELISM,
             'hmac_size': HMAC_SIZE
         },
         'aws_validation': {

--- a/tests/test_hello_crypto.py
+++ b/tests/test_hello_crypto.py
@@ -16,7 +16,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
     from hello_crypto import FileEncryptor, WindowsHelloError
-    from security_config import AES_KEY_SIZE, AES_BLOCK_SIZE
+    from security_config import (
+        AES_KEY_SIZE, AES_BLOCK_SIZE,
+        ARGON2_TIME_COST, ARGON2_MEMORY_COST, ARGON2_PARALLELISM,
+    )
+    from cryptography.hazmat.primitives.kdf.argon2 import Argon2id
 except ImportError as e:
     pytest.skip(f"Could not import hello_crypto modules: {e}", allow_module_level=True)
 
@@ -29,7 +33,16 @@ class TestFileEncryptor:
     
     @pytest.fixture
     def test_key(self):
-        return secrets.token_bytes(AES_KEY_SIZE)
+        password = b"test_password"
+        salt = b"test_salt_123456"  # 16 bytes
+        kdf = Argon2id(
+            salt=salt,
+            length=AES_KEY_SIZE,
+            iterations=ARGON2_TIME_COST,
+            lanes=ARGON2_PARALLELISM,
+            memory_cost=ARGON2_MEMORY_COST,
+        )
+        return kdf.derive(password)
     
     def test_encrypt_decrypt_data_roundtrip(self, encryptor, test_key):
         """Test that encryption and decryption work correctly."""
@@ -116,7 +129,7 @@ class TestFileEncryptor:
             await encryptor.encrypt_file("nonexistent.txt", "output.enc")
     
     @pytest.mark.asyncio
-    async def test_encrypt_decrypt_file_roundtrip(self, encryptor):
+    async def test_encrypt_decrypt_file_roundtrip(self, encryptor, test_key):
         """Test file encryption and decryption roundtrip (mocked Windows Hello)."""
         # Create test data
         test_data = b"This is test file content for encryption testing."
@@ -142,7 +155,7 @@ class TestFileEncryptor:
             with patch('hello_crypto.asyncio.to_thread', new_callable=AsyncMock) as mock_to_thread, \
                  patch.object(encryptor, 'is_supported', return_value=True), \
                  patch.object(encryptor, 'ensure_key_exists', return_value=None), \
-                 patch.object(encryptor, 'derive_key_from_signature', return_value=secrets.token_bytes(AES_KEY_SIZE)):
+                 patch.object(encryptor, 'derive_key_from_signature', return_value=test_key):
 
                 mock_to_thread.side_effect = side_effect
 
@@ -188,7 +201,16 @@ class TestErrorHandling:
     
     @pytest.fixture
     def test_key(self):
-        return secrets.token_bytes(AES_KEY_SIZE)
+        password = b"error_test_password"
+        salt = b"error_test_salt__"  # 16 bytes
+        kdf = Argon2id(
+            salt=salt,
+            length=AES_KEY_SIZE,
+            iterations=ARGON2_TIME_COST,
+            lanes=ARGON2_PARALLELISM,
+            memory_cost=ARGON2_MEMORY_COST,
+        )
+        return kdf.derive(password)
     
     def test_windows_hello_error(self):
         """Test WindowsHelloError exception."""
@@ -213,9 +235,8 @@ class TestErrorHandling:
                 except Exception:
                     pass  # Expected to fail
     
-    def test_data_validation_edge_cases(self, encryptor):
+    def test_data_validation_edge_cases(self, encryptor, test_key):
         """Test edge cases in data validation."""
-        test_key = secrets.token_bytes(AES_KEY_SIZE)
         
         # Test with various data sizes
         for size in [1, 15, 16, 17, 31, 32, 33, 1000]:


### PR DESCRIPTION
## Summary
- replace PBKDF2HMAC with Argon2id in Windows Hello key derivation
- store Argon2 parameters in security_config and remove PBKDF2 constants
- update tests and CI runner to use the new Argon2 KDF settings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b410cac4832093d39f04e857df9d