### PR TITLE
Add export-profile CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ aws-hello-creds remove-profile old-profile
 # Test credential retrieval (outputs JSON for credential_process)
 aws-hello-creds get-credentials --profile my-profile
 
+# Export profile credentials in plain text format
+aws-hello-creds export-profile my-profile
+
 # Set environment variables for shell session
 aws-hello-creds set-env my-profile
 

--- a/aws_hello_creds.py
+++ b/aws_hello_creds.py
@@ -841,9 +841,30 @@ async def output_credentials_json(profile_name: str) -> None:
             output["SessionToken"] = credentials["aws_session_token"]
             
         print(json.dumps(output))
-        
+
     except Exception as e:
         # Write error to stderr so it doesn't interfere with JSON output
+        print(f"Error retrieving credentials: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+async def output_credentials_plaintext(profile_name: str) -> None:
+    """Output credentials in plain text key=value format."""
+    manager = AWSCredentialManager()
+
+    try:
+        credentials = await manager.get_credentials(profile_name)
+
+        print(f"aws_access_key_id={credentials['aws_access_key_id']}")
+        print(f"aws_secret_access_key={credentials['aws_secret_access_key']}")
+
+        if "aws_session_token" in credentials:
+            print(f"aws_session_token={credentials['aws_session_token']}")
+
+        if "region" in credentials:
+            print(f"region={credentials['region']}")
+
+    except Exception as e:
         print(f"Error retrieving credentials: {e}", file=sys.stderr)
         sys.exit(1)
 
@@ -933,7 +954,14 @@ Security Features:
     # Get credentials command (for credential_process)
     get_parser = subparsers.add_parser("get-credentials", help="Get credentials for a profile (credential_process format)")
     get_parser.add_argument("--profile", required=True, help="Profile name")
-    
+
+    # Export plain text credentials command
+    export_parser = subparsers.add_parser(
+        "export-profile",
+        help="Export decrypted credentials for a profile in plain text"
+    )
+    export_parser.add_argument("profile_name", help="Profile name")
+
     # Set environment variables command
     env_parser = subparsers.add_parser("set-env", help="Output commands to set AWS environment variables")
     env_parser.add_argument("profile_name", help="Profile name")
@@ -989,7 +1017,10 @@ Security Features:
             
         elif args.command == "get-credentials":
             await output_credentials_json(args.profile)
-            
+
+        elif args.command == "export-profile":
+            await output_credentials_plaintext(args.profile_name)
+
         elif args.command == "set-env":
             await manager.output_env_vars(args.profile_name, args.shell)
             

--- a/docs/PYPI_DEPLOYMENT.md
+++ b/docs/PYPI_DEPLOYMENT.md
@@ -36,6 +36,9 @@ aws-hello-creds set-env work
 
 # Get credentials for AWS CLI
 aws-hello-creds get-credentials --profile work
+
+# Export profile credentials in plain text
+aws-hello-creds export-profile work
 ```
 
 #### File Encryption

--- a/tests/test_aws_hello_creds.py
+++ b/tests/test_aws_hello_creds.py
@@ -252,6 +252,64 @@ class TestCLIFunctions:
                 
             finally:
                 sys.stdout = sys.__stdout__
+
+    @pytest.mark.asyncio
+    async def test_output_credentials_plaintext(self):
+        """Test plain text credential export."""
+        test_credentials = {
+            "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+            "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "region": "us-east-1",
+        }
+
+        with patch('aws_hello_creds.AWSCredentialManager') as mock_manager_class:
+            mock_manager = MagicMock()
+            mock_manager.get_credentials = AsyncMock(return_value=test_credentials)
+            mock_manager_class.return_value = mock_manager
+
+            import io
+            import sys
+            captured_output = io.StringIO()
+            sys.stdout = captured_output
+
+            try:
+                await aws_hello_creds.output_credentials_plaintext("test-profile")
+                output = captured_output.getvalue().splitlines()
+
+                assert "aws_access_key_id=AKIAIOSFODNN7EXAMPLE" in output
+                assert "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" in output
+                assert "region=us-east-1" in output
+
+            finally:
+                sys.stdout = sys.__stdout__
+
+    @pytest.mark.asyncio
+    async def test_output_credentials_plaintext_with_session_token(self):
+        """Test plain text output including session token."""
+        test_credentials = {
+            "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+            "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "aws_session_token": "IQoJb3JpZ2luX2V" + "x" * 100,
+        }
+
+        with patch('aws_hello_creds.AWSCredentialManager') as mock_manager_class:
+            mock_manager = MagicMock()
+            mock_manager.get_credentials = AsyncMock(return_value=test_credentials)
+            mock_manager_class.return_value = mock_manager
+
+            import io
+            import sys
+            captured_output = io.StringIO()
+            sys.stdout = captured_output
+
+            try:
+                await aws_hello_creds.output_credentials_plaintext("test-profile")
+                output = captured_output.getvalue().splitlines()
+
+                assert "aws_session_token=" + test_credentials["aws_session_token"] in output
+
+            finally:
+                sys.stdout = sys.__stdout__
     
     @pytest.mark.asyncio
     async def test_output_credentials_json_with_session_token(self):


### PR DESCRIPTION
## Summary
- add `export-profile` verb and supporting function to output decrypted credentials as plain text
- document plain text export command in README and deployment docs
- cover new export functionality with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b6dc23808320b3eaff9bcb6efed8